### PR TITLE
doc: Add issue template and dependabot

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -2,29 +2,29 @@ name: Bug Report
 description: File a bug report
 title: '[Bug]: '
 labels:
-    - bug
+  - bug
 body:
-    - type: textarea
-      id: description
-      attributes:
-          label: What happened?
-          description: Please leave a brief description about the bug you file.
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Please leave a brief description about the bug you file.
       validations:
-          required: true
-          
-    - type: textarea
-      id: log
-      attributes:
-          label: The command and output
-          description: Please provide us the command and output you are running
+        required: true
+
+  - type: textarea
+    id: log
+    attributes:
+      label: The command and output
+      description: Please provide us the command and output you are running
       validations:
+        required: true
+
+  - type: checkboxes
+    id: no-similar-issue
+    attributes:
+      label: No similar issue
+      description: There is no similar issue found in the [issues](https://github.com/iffse/pay-respects/issues)
+      options:
+        - label: I have searched the issue list and there is no similar issue found
           required: true
-          
-    - type: checkboxes
-      id: no-similar-issue
-      attributes:
-          label: No similar issue
-          description: There is no similar issue found in the [issues](https://github.com/iffse/pay-respects/issues)
-          options:
-              - label: I have searched the issue list and there is no similar issue found
-                required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -16,7 +16,7 @@ body:
       id: log
       attributes:
           label: The command and output
-          description: Please give me the command and output you are running
+          description: Please provide us the command and output you are running
       validations:
           required: true
           

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,30 @@
+name: Bug Report
+description: File a bug report
+title: '[Bug]: '
+labels:
+    - bug
+body:
+    - type: textarea
+      id: description
+      attributes:
+          label: What happened?
+          description: Please leave a brief description about the bug you files.
+      validations:
+          required: true
+          
+    - type: textarea
+      id: log
+      attributes:
+          label: The command and output
+          description: Please give me the command and output you are running
+      validations:
+          required: true
+          
+    - type: checkboxes
+      id: no-similar-issue
+      attributes:
+          label: No similar issue
+          description: There is no similar issue found in the [issues](https://github.com/iffse/pay-respects/issues)
+          options:
+              - label: I have searched the issue list and there is no similar issue found
+                required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -8,7 +8,7 @@ body:
       id: description
       attributes:
           label: What happened?
-          description: Please leave a brief description about the bug you files.
+          description: Please leave a brief description about the bug you file.
       validations:
           required: true
           

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -2,12 +2,12 @@ name: Feature Request
 description: File a feature request
 title: '[Feature Request]: '
 labels:
-    - feature-request
+  - feature-request
 body:
-    - type: textarea
-      id: feature-request-content
-      attributes:
-          label: What do you want us to work on?
-          description: Please let us know what do you think
+  - type: textarea
+    id: feature-request-content
+    attributes:
+      label: What do you want us to work on?
+      description: Please let us know what do you think
       validations:
-          required: true
+        required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -4,7 +4,7 @@ title: '[Feature Request]: '
 labels:
     - feature-request
 body:
-    - type: textareas
+    - type: textarea
       id: feature-request-content
       attributes:
           label: What do you want us to work on?

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,0 +1,13 @@
+name: Feature Request
+description: File a feature request
+title: '[Feature Request]: '
+labels:
+    - feature-request
+body:
+    - type: textareas
+      id: feature-request-content
+      attributes:
+          label: What do you want us to work on?
+          description: Please let us know what do you think
+      validations:
+          required: true

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: weekly
+    - package-ecosystem: cargo
+      directory: /
+      schedule:
+          interval: weekly

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,10 +1,10 @@
 version: 2
 updates:
-    - package-ecosystem: github-actions
-      directory: /
-      schedule:
-          interval: weekly
-    - package-ecosystem: cargo
-      directory: /
-      schedule:
-          interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Using dependabot for updating depends(rust and github actions)
Adding issue template for better user experience 
As most changes are not related to actual code, adding `[skip ci]` in almost all commits(I forgot to add for some of the commits)