### PR TITLE
feat(rules): add yarn

### DIFF
--- a/rules/yarn.toml
+++ b/rules/yarn.toml
@@ -2,8 +2,9 @@ command = "yarn"
 
 [[match_err]]
 pattern = [
-  "error `install` has been replaced with `add` to add new dependencies.",
+	"error `install` has been replaced with `add` to add new dependencies."
 ]
-suggest = ['''
-yarn add {{command[2:]}}
-''']
+suggest = [
+'''
+yarn add {{command[2:]}} '''
+]

--- a/rules/yarn.toml
+++ b/rules/yarn.toml
@@ -1,0 +1,9 @@
+command = "yarn"
+
+[[match_err]]
+pattern = [
+  "error `install` has been replaced with `add` to add new dependencies.",
+]
+suggest = ['''
+yarn add {{command[2:]}}
+''']


### PR DESCRIPTION
Error:
```
> yarn install alpinejs                                                                                                                                                                                    
yarn install v1.22.22
error `install` has been replaced with `add` to add new dependencies. Run "yarn add alpinejs" instead.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

```
> f                                                                                                                                                                                                    
yarn add alpinejs


Press enter to execute the suggestion. Or press Ctrl+C to exit.
```