### PR TITLE
flake.nix: fix build and make the derivation more maintainable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+result

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
         genAttrs
         importTOML
         licenses
-        sourceByRegex
+        cleanSource
         ;
 
       eachSystem =
@@ -28,14 +28,9 @@
       packages = eachSystem (
         pkgs:
         let
-          src = sourceByRegex self [
-            "(core)(/.*)?"
-            "(module-runtime-rules)(/.*)?"
-            "(module-request-ai)(/.*)?"
-            "(rules)(/.*)?"
-            ''Cargo\.(toml|lock)''
-          ];
-
+        
+        src = cleanSource self
+        
           inherit (pkgs)
             rustPlatform
             openssl

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,6 @@
         genAttrs
         importTOML
         licenses
-        maintainers
         sourceByRegex
         ;
 
@@ -61,7 +60,6 @@
               description = "Command suggestions, command-not-found and thefuck replacement written in Rust";
               license = licenses.agpl3Plus;
               homepage = "https://github.com/iffse/pay-respects";
-              maintainers = with maintainers; [ iff ];
               mainProgram = "pay-respects";
             };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
             rustPlatform
             openssl
             pkg-config
+            versionCheckHook
             ;
         in
         {
@@ -45,12 +46,12 @@
 
             inherit src;
 
-            cargoLock = {
-              lockFile = src + "/Cargo.lock";
-            };
+            cargoLock.lockFile = src + "/Cargo.lock";
 
             nativeBuildInputs = [ pkg-config ];
             buildInputs = [ openssl ];
+
+            nativeInstallCheckInputs = [ versionCheckHook ];
 
             meta = {
               inherit (cargoPackage) description homepage;

--- a/flake.nix
+++ b/flake.nix
@@ -28,9 +28,10 @@
       packages = eachSystem (
         pkgs:
         let
-        
-        src = cleanSource self
-        
+          cargoPackage = (importTOML (src + "/core/Cargo.toml")).package;
+
+          src = cleanSource self;
+
           inherit (pkgs)
             rustPlatform
             openssl
@@ -39,8 +40,8 @@
         in
         {
           default = rustPlatform.buildRustPackage {
-            pname = "pay-respects";
-            inherit ((importTOML (src + "/core/Cargo.toml")).package) version;
+            pname = cargoPackage.name;
+            inherit (cargoPackage) version;
 
             inherit src;
 
@@ -52,9 +53,8 @@
             buildInputs = [ openssl ];
 
             meta = {
-              description = "Command suggestions, command-not-found and thefuck replacement written in Rust";
+              inherit (cargoPackage) description homepage;
               license = licenses.agpl3Plus;
-              homepage = "https://github.com/iffse/pay-respects";
               mainProgram = "pay-respects";
             };
           };


### PR DESCRIPTION
### Fixes #20

## Description of Changes
- Adds Nix build results to `.gitignore`
- Removes `iff` from `maintainers` since it'll cause a evaluation failure with `check-meta` as `lib.maintainers.iff` does not exist.
- Removes the regex in `src` as it isn't strictly necessary for this project and introduces difficulties when refactoring the repository structure.
- Deduplicates some package metadata attributes by inheriting from Cargo.toml, removing the need to update those strings twice.
- Adds `versionCheckHook` as a simple test that the version of the project matches the version we expect.