### PR TITLE
specify "core" as default workspace member

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
 	"module-runtime-rules",
 	"module-request-ai",
 ]
+default-members = ["core"]
 
 [profile.release]
 strip = true


### PR DESCRIPTION
This fixes the error
```
error: `cargo run` could not determine which binary to run. Use the `--bin` option to specify a binary, or the `default-run` manifest key.
available binaries: _pay-respects-fallback-100-request-ai, _pay-respects-module-100-runtime-rules, pay-respects
```

trying to run `cargo run` at the root