### PR TITLE
add rules for jj

### DIFF
--- a/rules/jj.toml
+++ b/rules/jj.toml
@@ -1,0 +1,28 @@
+command = "jj"
+
+[[match_err]]
+pattern = [
+	"pass `--ignore-immutable`"
+]
+suggest = [
+'''
+{{command}} --ignore-immutable'''
+]
+
+[[match_err]]
+pattern = [
+	"Use --allow-new to push new bookmark."
+]
+suggest = [
+'''
+{{command}} --allow-new'''
+]
+
+[[match_err]]
+pattern = [
+	"No bookmarks found in the default push revset:"
+]
+suggest = [
+'''
+{{command}} --change @'''
+]

--- a/rules/jj.toml
+++ b/rules/jj.toml
@@ -11,7 +11,7 @@ suggest = [
 
 [[match_err]]
 pattern = [
-	"Use --allow-new to push new bookmark."
+	"use --allow-new to push new bookmark"
 ]
 suggest = [
 '''
@@ -20,7 +20,7 @@ suggest = [
 
 [[match_err]]
 pattern = [
-	"No bookmarks found in the default push revset:"
+	"no bookmarks found in the default push revset"
 ]
 suggest = [
 '''


### PR DESCRIPTION
jj is a version control tool: https://github.com/jj-vcs/jj

- `--ignore-immutable` and `--allow-new` are hints from jj itself
- when `jj git push` fails with `no bookmarks found in the default push revset` you either want to create a new bookmark, or do `jj git push --change @` (aka `jj git push --change` aka `jj git push -c`) or create a new bookmark. But if you're typing `f` it's probably the latter