### PR TITLE
fix unwrap panic on unexpected nix-index output

### DIFF
--- a/core/src/system.rs
+++ b/core/src/system.rs
@@ -112,18 +112,21 @@ pub fn get_packages(
 			if result.is_empty() {
 				return None;
 			}
-			let packages: Vec<String> = result
+			let packages: Option<Vec<String>> = result
 				.lines()
 				.map(|line| {
-					line.split_whitespace()
-						.next()
-						.unwrap()
-						.rsplit_once('.')
-						.unwrap()
-						.0
-						.to_string()
+					let package = line.split_whitespace().next()?;
+					Some(package.rsplit_once('.')?.0.to_string())
 				})
 				.collect();
+			let Some(packages) = packages else {
+				eprintln!(
+					"Unexpected output from nix-index:\n  {}",
+					result.replace("\n", "\n  ")
+				);
+				return None;
+			};
+
 			if packages.is_empty() {
 				None
 			} else {


### PR DESCRIPTION
New output:
```
$ asdf
fish: Command not found: asdf

Unexpected output from nix-index:
  error: reading from the database at '/home/jakob/.cache/nix-index/files' failed.
  This may be caused by a corrupt or missing database, try (re)running `nix-index` to generate the database. 
  If the error persists please file a bug report at https://github.com/nix-community/nix-index.
  caused by: No such file or directory (os error 2)
  
pay-respects: No matching package found
```