### PR TITLE
fix: reduce the number of erroneous matches in nix-index

### DIFF
--- a/core/src/system.rs
+++ b/core/src/system.rs
@@ -125,7 +125,7 @@ pub fn get_packages(
 				);
 				return None;
 			}
-			let result = command_output(shell, &format!("nix-locate 'bin/{}'", executable));
+			let result = command_output(shell, &format!("nix-locate --regex 'bin/{}$'", executable));
 			if result.is_empty() {
 				return None;
 			}


### PR DESCRIPTION
This is a trivial, one-line change.

`nix-index` is overly eager to match for binary names that aren't quite what you want. For instance, searching for `umr` will also match `umrtest` and `umrgui`, as shown below:

```console
$ nix-locate 'bin/umr'
umr.out                                       1,791,544 x /nix/store/55d7kkkrv89xnjcfi0rlpfn2lg6daf13-umr-1.0.10/bin/umr
umr.out                                               0 s /nix/store/55d7kkkrv89xnjcfi0rlpfn2lg6daf13-umr-1.0.10/bin/umrgui
umr.out                                         722,672 x /nix/store/55d7kkkrv89xnjcfi0rlpfn2lg6daf13-umr-1.0.10/bin/umrtest
```

This causes the following incorrect behaviour in `pay-respects`:

```console
$ umr
fish: Command not found: umr

Package(s) for the missing command found:
[↑/↓/j/k] [Enter] [ESC]

> 1) umr
  2) umr
  3) umr
```

Options 1, 2 and 3 are referring to the same package. By ensuring the store path ends after the user's input, we avoid matching for binaries that aren't what the user expects, and also reduce on the number of duplicates in pay-respects' suggestions:

```console
$ nix-locate --regex 'bin/umr$'
umr.out                                       1,791,544 x /nix/store/55d7kkkrv89xnjcfi0rlpfn2lg6daf13-umr-1.0.10/bin/umr

$ nix-locate --regex 'bin/umrtest$'
umr.out                                         722,672 x /nix/store/55d7kkkrv89xnjcfi0rlpfn2lg6daf13-umr-1.0.10/bin/umrtest
```