### PR TITLE
Add a zsh framework-compatible plugin file

### DIFF
--- a/pay-respects.zsh
+++ b/pay-respects.zsh
@@ -1,0 +1,9 @@
+#
+# Make it easier for zsh plugin managers to load pay-respects
+#
+
+if which pay-respects > /dev/null 2>&1; then
+  eval "$(pay-respects zsh --alias)"
+else
+  echo "pay-respects is not in $PATH"
+fi


### PR DESCRIPTION
Add a plugin file that is compatible with the ZSH plugin standard (see https://wiki.zshell.dev/community/zsh_plugin_standard).

This allows ZSH frameworks to automatically load pay-respects if it is instlled on a machine.

The plugin file will only be used by ZSH frameworks and will not interfere when people are not using one.