### PR TITLE
fix: remove ';return' from nix shell command execution

### DIFF
--- a/core/src/system.rs
+++ b/core/src/system.rs
@@ -259,7 +259,7 @@ pub fn shell_package(data: &Data, package_manager: &str, package: &str) -> Strin
 	match package_manager {
 		"guix" => format!("guix shell {} -- {}", package, command),
 		"nix" => format!(
-			r#"nix shell nixpkgs#{} --command "{};return""#,
+			r#"nix shell nixpkgs#{} --command "{}""#,
 			package, command
 		),
 		_ => unreachable!("Only `nix` and `guix` are supported for shell installation"),


### PR DESCRIPTION
thank you for adding nix shell support! us declarative freaks will really appreciate it.

this fixes command not found errors caused by nix trying to execute 'command;return' as a single executable name.