### PR TITLE
fix(nix): use nix shell -c and improve nix-index usage

### DIFF
--- a/core/src/system.rs
+++ b/core/src/system.rs
@@ -139,7 +139,13 @@ pub fn get_packages(
 				return None;
 			}
 			let result =
-				command_output(shell, &format!("nix-locate --regex 'bin/{}$'", executable));
+				command_output(
+					shell,
+					&format!(
+						"nix-locate --minimal --no-group --top-level --type x --type s --whole-name --at-root '/bin/{}'", 
+						executable,
+					),
+				);
 			if result.is_empty() {
 				return None;
 			}
@@ -149,9 +155,7 @@ pub fn get_packages(
 					line.split_whitespace()
 						.next()
 						.unwrap()
-						.rsplit_once('.')
-						.unwrap()
-						.0
+						.trim_end_matches(".out") // remove .out, keep the rest as is
 						.to_string()
 				})
 				.collect();
@@ -258,10 +262,7 @@ pub fn shell_package(data: &Data, package_manager: &str, package: &str) -> Strin
 
 	match package_manager {
 		"guix" => format!("guix shell {} -- {}", package, command),
-		"nix" => format!(
-			r#"nix-shell -p {} --command "{};return""#,
-			package, command
-		),
+		"nix" => format!(r#"nix shell nixpkgs#{} -c {}"#, package, command),
 		_ => unreachable!("Only `nix` and `guix` are supported for shell installation"),
 	}
 }


### PR DESCRIPTION
This improves the nix-locate command usage by only using toplevel attrs (the others in brackets don't parse correctly anyways and don't include the binary we want, at least not from my testing) and correctly parsing the output, only removing `.out` since it's the default. Other endings like `.bin` etc. are kept to be safe.

Also, `nix shell nixpkgs#package -c some command here` works fine as is, so this goes back to nix shell instead of `nix-shell`. We also don't need a "return" in there, nix just runs the command in the shell and returns itself. 

I feel like this is the best approach, throwing the user in a nix shell isn't very nice imo, especially since the current command does not respect my shell and just throws me into bash.