### PR TITLE
Replace nix-locate with nix-search-cli

### DIFF
--- a/core/src/system.rs
+++ b/core/src/system.rs
@@ -131,15 +131,15 @@ pub fn get_packages(
 			}
 		}
 		"nix" => {
-			if !data.executables.contains(&"nix-locate".to_string()) {
+			if !data.executables.contains(&"nix-search".to_string()) {
 				eprintln!(
-					"{} nix-index is required to find packages",
+					"{} nix-search-cli is required to find packages",
 					"pay-respects:".yellow()
 				);
 				return None;
 			}
 			let result =
-				command_output(shell, &format!("nix-locate --regex 'bin/{}$'", executable));
+				command_output(shell, &format!("nix-search '{}'", executable));
 			if result.is_empty() {
 				return None;
 			}
@@ -149,9 +149,6 @@ pub fn get_packages(
 					line.split_whitespace()
 						.next()
 						.unwrap()
-						.rsplit_once('.')
-						.unwrap()
-						.0
 						.to_string()
 				})
 				.collect();


### PR DESCRIPTION
`nix-index` which creates the database for `nix-locate` is prohibitively resource intensive (see https://github.com/nix-community/nix-index/issues/64). This fork/PR thus replaces its use with `nix-search-cli` (https://github.com/peterldowns/nix-search-cli) which serves as a wrapper around nix's online package search—making it a practical alternative for more resource constrained devices 