### PR TITLE
fix: quote exe path in init.nu template

### DIFF
--- a/core/templates/init.nu
+++ b/core/templates/init.nu
@@ -1,4 +1,4 @@
 def --env {{ alias }} [] {
-	let dir = (with-env { _PR_LAST_COMMAND: (history | last).command, _PR_ALIAS: (help aliases | select name expansion | each ({ |row| $row.name + "=" + $row.expansion }) | str join (char nl)), _PR_SHELL: nu } { {{ binary_path }} })
+	let dir = (with-env { _PR_LAST_COMMAND: (history | last).command, _PR_ALIAS: (help aliases | select name expansion | each ({ |row| $row.name + "=" + $row.expansion }) | str join (char nl)), _PR_SHELL: nu } { `{{ binary_path }}` })
 	cd $dir
 }


### PR DESCRIPTION
This PR quotes `binary_path` in the Nushell initialization template.

Resolves #95.