### PR TITLE
Use `git remote` to retrieve configured endpoints

### DIFF
--- a/rules/git.toml
+++ b/rules/git.toml
@@ -84,12 +84,13 @@ git checkout -b {{command[2]}} '''
 
 [[match_err]]
 pattern = [
-	"has no upstream branch"
+	"has no upstream branch",
+	"No configured push destination.",
 ]
 suggest = [
 '''
 #[cmd_contains(push)]
-git push --set-upstream origin {{shell(git rev-parse --abbrev-ref HEAD)}} '''
+git push --set-upstream {{select({{shell(git remote)}})}} {{shell(git rev-parse --abbrev-ref HEAD)}} ''',
 ]
 
 [[match_err]]
@@ -99,7 +100,7 @@ pattern = [
 suggest = [
 '''
 #[cmd_contains(pull)]
-git pull --set-upstream origin {{shell(git rev-parse --abbrev-ref HEAD)}} '''
+git pull --set-upstream {{select({{shell(git remote)}})}} {{shell(git rev-parse --abbrev-ref HEAD)}} '''
 ]
 
 [[match_err]]

--- a/utils/src/evals.rs
+++ b/utils/src/evals.rs
@@ -55,6 +55,7 @@ pub fn eval_shell_command(shell: &str, command: &str) -> Vec<String> {
 	split_output
 		.iter()
 		.map(|s| s.trim().to_string())
+		.filter(|s| !s.is_empty())
 		.collect::<Vec<String>>()
 }
 


### PR DESCRIPTION
Closes #97

The added pattern is because when there's only 1 remote setup, the error messages looks like
```sh
$ git push
fatal: The current branch git-anne has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream nas main

To have this happen automatically for branches without a tracking
upstream, see 'push.autoSetupRemote' in 'git help config'.
```

but when there's more than 1 remote, the error message looks like:
```sh
$ git push
fatal: No configured push destination.
Either specify the URL from the command-line or configure a remote repository using

    git remote add <name> <url>

and then push using the remote name

    git push <name>
```

## After this PR

### Test config
```sh
cat .git/config
[core]
	repositoryformatversion = 0
	filemode = true
[remote "nas"]
	url = ...
	fetch = ...
[remote "my_remote"]
	url = ...
	fetch = ...
[remote "new remote 2"]
	url = ...
	fetch = ...
```

### Results

```sh
$ git push
fatal: No configured push destination.
Either specify the URL from the command-line or configure a remote repository using

    git remote add <name> <url>

and then push using the remote name

    git push <name>

$ f
3 suggestion(s) found
[↑/↓/j/k] [Enter] [ESC] 
  
> git push --set-upstream my_remote main
  git push --set-upstream nas main
  git push --set-upstream new remote 2 main
```

----

## Note on the filter:

Shell command tends to have trailing newline; (e.g. from `git remote`) hence the filter