### PR TITLE
Fix panic in shell.rs when parsing malformed aliases #100

### DIFF
--- a/core/src/shell.rs
+++ b/core/src/shell.rs
@@ -238,37 +238,48 @@ pub fn alias_map(shell: &str) -> Option<HashMap<String, String>> {
 		"bash" => {
 			for line in env.lines() {
 				let alias = line.replace("alias ", "");
-				let (alias, command) = alias.split_once('=').unwrap();
-				let command = command.trim().trim_matches('\'');
-				alias_map.insert(alias.to_string(), command.to_string());
+				if let Some((alias, command)) = alias.split_once('=') {
+					let command = command.trim().trim_matches('\'');
+					alias_map.insert(alias.to_string(), command.to_string());
+				}
+				// Skip lines without '=', they're malformed
 			}
 		}
 		"zsh" => {
 			for line in env.lines() {
-				let (alias, command) = line.split_once('=').unwrap();
-				let command = command.trim().trim_matches('\'');
-				alias_map.insert(alias.to_string(), command.to_string());
+				if let Some((alias, command)) = line.split_once('=') {
+					let command = command.trim().trim_matches('\'');
+					alias_map.insert(alias.to_string(), command.to_string());
+				}
+				// Skip lines without '=', they're malformed
 			}
 		}
 		"fish" => {
 			for line in env.lines() {
 				let alias = line.replace("alias ", "");
-				let (alias, command) = alias.split_once(' ').unwrap();
-				let command = command.trim().trim_matches('\'');
-				alias_map.insert(alias.to_string(), command.to_string());
+				if let Some((alias, command)) = alias.split_once(' ') {
+					let command = command.trim().trim_matches('\'');
+					alias_map.insert(alias.to_string(), command.to_string());
+				}
+				// Skip lines without ' ', they're malformed
 			}
 		}
 		"nu" | _ => {
 			for line in env.lines() {
-				let (alias, command) = line.split_once('=').unwrap();
-				alias_map.insert(alias.to_string(), command.to_string());
+				if let Some((alias, command)) = line.split_once('=') {
+					alias_map.insert(alias.to_string(), command.to_string());
+				}
+				// Skip lines without '=', they're malformed
 			}
 		}
 	}
 	std::env::remove_var("_PR_ALIAS");
-	Some(alias_map)
+	if alias_map.is_empty() {
+		None
+	} else {
+		Some(alias_map)
+	}
 }
-
 pub fn expand_alias(map: &HashMap<String, String>, command: &str) -> Option<String> {
 	let (command, args) = if let Some(split) = command.split_once(' ') {
 		(split.0, split.1)


### PR DESCRIPTION
## Description
Fixes #100: thread 'main' panicked at core/src/shell.rs

### Problem
The `alias_map()` function would panic with `called Option::unwrap() on a None value` when:
- Environment variable `_PR_ALIAS` contains malformed lines without expected delimiters
- Different shells have different alias formats (bash/zsh use `=`, fish uses space)
- Reported by @SimonErkelens-MetService

### Solution
1. **Replaced unsafe `unwrap()` calls** with `if let Some((...))` pattern matching
2. **Added validation** for each shell's expected alias format:
   - `bash`: Expects `alias name='command'` format (removes "alias " prefix)
   - `zsh`: Expects `name='command'` format  
   - `fish`: Expects `alias name command` format (space-separated)
   - `nu`: Expects `name=command` format
3. **Graceful handling** of malformed lines - they're skipped instead of causing panics
4. **Empty map detection** - returns `None` if no valid aliases are found

### Changes Made
- `core/src/shell.rs`: Fixed `alias_map()` function (lines ~241)
- All shell formats now validated before parsing
- Malformed input lines are silently skipped
- Cleaner error handling throughout

### Testing
- Manually tested with malformed alias input (no panic)
- Tested with empty input (returns `None`)
- Tested with valid aliases (parses correctly)
- Tested across all shell formats (bash, zsh, fish, nu)
- Existing test suite passes: `cargo test` succeeds

### Impact
- Prevents terminal crashes when users have malformed shell aliases
- More robust parsing of shell environment variables
- Better user experience with graceful error handling
- Follows Rust best practices (avoiding `unwrap()` on user input)

Fixes #100