### PR TITLE
build(flake): update nixpkgs input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733759999,
-        "narHash": "sha256-463SNPWmz46iLzJKRzO3Q2b0Aurff3U1n0nYItxq7jU=",
+        "lastModified": 1770141374,
+        "narHash": "sha256-yD4K/vRHPwXbJf5CK3JkptBA6nFWUKNX/jlFp2eKEQc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a73246e2eef4c6ed172979932bc80e1404ba2d56",
+        "rev": "41965737c1797c1d83cfb0b644ed0840a6220bd1",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   };
 
   outputs =


### PR DESCRIPTION
- [v0.7.10 updates `askama` to 0.15](https://github.com/iffse/pay-respects/blame/1a689e6de3189cf8703d49ca8cb2f2f3a8addd9d/core/Cargo.toml#L21), which [requires `edition2024`](https://github.com/askama-rs/askama/commit/79d8f8886be64baf29da11c05f66b47f76464cea) as shown in the build log below
- as [macos is supported](https://github.com/iffse/pay-respects/commit/5a64e6c6c80c1593118672c72f25b2d2ffa962d8), [the input should be pointed to `nixpkgs-unstable` branch](https://nix.dev/concepts/faq#rolling)

<details>

<summary>build log</summary>

```shell
> nix log --refresh --repair --debug --print-build-logs --verbose -- github:iffse/pay-respects/1a689e6de3189cf8703d49ca8cb2f2f3a8addd9d

evaluating file '«nix-internal»/derivation-internal.nix'
evaluating derivation 'github:iffse/pay-respects/1a689e6de3189cf8703d49ca8cb2f2f3a8addd9d#packages.x86_64-linux.default'...
using cache entry 'gitRevToTreeHash:{"rev":"1a689e6de3189cf8703d49ca8cb2f2f3a8addd9d"}' -> '{"treeHash":"820e2f3b5c816f318295c858056b0d91a226cf7d"}'
using cache entry 'gitRevToLastModified:{"rev":"1a689e6de3189cf8703d49ca8cb2f2f3a8addd9d"}' -> '{"lastModified":1770128291}'
got tree '«github:iffse/pay-respects/1a689e6de3189cf8703d49ca8cb2f2f3a8addd9d»/' from 'github:iffse/pay-respects/1a689e6de3189cf8703d49ca8cb2f2f3a8addd9d'
evaluating file '«github:iffse/pay-respects/1a689e6de3189cf8703d49ca8cb2f2f3a8addd9d»/flake.nix'
using cache entry 'fetchToStore:{"fingerprint":"1a689e6de3189cf8703d49ca8cb2f2f3a8addd9d","method":"nar","name":"source","path":"/","store":"/nix/store"}' -> '{"storePath":"wma939m2bi9fh7dsrvs2nhnivv2bc7mz-source"}'
performing daemon worker op: 11
acquiring write lock on '/nix/var/nix/temproots/153677'
performing daemon worker op: 1
using cache entry 'fetchToStore:{"fingerprint":"1a689e6de3189cf8703d49ca8cb2f2f3a8addd9d","method":"nar","name":"source","path":"/","store":"/nix/store"}' -> 'null', '/nix/store/wma939m2bi9fh7dsrvs2nhnivv2bc7mz-source'
store path cache hit for '«github:iffse/pay-respects/1a689e6de3189cf8703d49ca8cb2f2f3a8addd9d»/'
performing daemon worker op: 26
evaluating file '«github:iffse/pay-respects/1a689e6de3189cf8703d49ca8cb2f2f3a8addd9d»/flake.nix'
performing daemon worker op: 19
old lock file: {
  "nodes": {
    "nixpkgs": {
      "locked": {
        "lastModified": 1733759999,
        "narHash": "sha256-463SNPWmz46iLzJKRzO3Q2b0Aurff3U1n0nYItxq7jU=",
        "owner": "nixos",
        "repo": "nixpkgs",
        "rev": "a73246e2eef4c6ed172979932bc80e1404ba2d56",
        "type": "github"
      },
      "original": {
        "owner": "nixos",
        "ref": "nixos-unstable",
        "repo": "nixpkgs",
        "type": "github"
      }
    },
    "root": {
      "inputs": {
        "nixpkgs": "nixpkgs"
      }
    }
  },
  "root": "root",
  "version": 7
}
computing lock file node ''
computing input 'nixpkgs'
keeping existing input 'nixpkgs'
computing lock file node 'nixpkgs'
new lock file: {
  "nodes": {
    "nixpkgs": {
      "locked": {
        "lastModified": 1733759999,
        "narHash": "sha256-463SNPWmz46iLzJKRzO3Q2b0Aurff3U1n0nYItxq7jU=",
        "owner": "nixos",
        "repo": "nixpkgs",
        "rev": "a73246e2eef4c6ed172979932bc80e1404ba2d56",
        "type": "github"
      },
      "original": {
        "owner": "nixos",
        "ref": "nixos-unstable",
        "repo": "nixpkgs",
        "type": "github"
      }
    },
    "root": {
      "inputs": {
        "nixpkgs": "nixpkgs"
      }
    }
  },
  "root": "root",
  "version": 7
}
trying flake output attribute 'packages.x86_64-linux.default'
trying flake output attribute 'defaultPackage.x86_64-linux'
using cached attrset attribute ''
using cached string attribute 'packages.x86_64-linux.default.type'
using cached string attribute 'packages.x86_64-linux.default.drvPath'
performing daemon worker op: 1
using cached list of strings attribute 'packages.x86_64-linux.default.meta.outputsToInstall'
got build log for 'github:iffse/pay-respects/1a689e6de3189cf8703d49ca8cb2f2f3a8addd9d#packages.x86_64-linux.default' from 'daemon'
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/wma939m2bi9fh7dsrvs2nhnivv2bc7mz-source
source root is source
Executing cargoSetupPostUnpackHook
Finished cargoSetupPostUnpackHook
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Executing cargoSetupPostPatchHook
Validating consistency between /build/source/Cargo.lock and /build/cargo-vendor-dir/Cargo.lock
Finished cargoSetupPostPatchHook
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Executing cargoBuildHook
cargoBuildHook flags: -j 16 --target x86_64-unknown-linux-gnu --offline --profile release
[1m[31merror[0m[1m:[0m failed to get `askama` as a dependency of package `pay-respects v0.7.10 (/build/source/core)`

Caused by:
  failed to load source for dependency `askama`

Caused by:
  Unable to update registry `crates-io`

Caused by:
  failed to update replaced source registry `crates-io`

Caused by:
  failed to parse manifest at `/build/cargo-vendor-dir/askama-0.15.4/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.82.0 (8f40fc59f 2024-08-21)).
  Consider trying a more recent nightly release.
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
```

</details>
