### PR TITLE
core: update Cargo.toml version

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pay-respects"
 authors = ["iff <iff@ik.me>"]
-version = "0.7.11"
+version = "0.7.12"
 edition = "2021"
 
 # for crates.io


### PR DESCRIPTION
This will correct the version that the binary outputs upon calling `pay-respects --version`.