### PR TITLE
fix: replace line-oriented tag parsing with scan-based approach in buffer.rs

### DIFF
--- a/module-request-ai/src/buffer.rs
+++ b/module-request-ai/src/buffer.rs
@@ -48,6 +48,21 @@ const TAGS: &[&str] = &[
 	"</think>",
 ];
 
+/// Used by `partial_tag_len` to limit how far back it scans for a suffix
+/// that could be the start of a tag. Computed at compile time so it stays
+/// in sync when tags are added or removed.
+const MAX_TAG_LEN: usize = {
+	let mut max = 0;
+	let mut i = 0;
+	while i < TAGS.len() {
+		if TAGS[i].len() > max {
+			max = TAGS[i].len();
+		}
+		i += 1;
+	}
+	max
+};
+
 pub struct Buffer {
 	pub buf: String,
 	pending: String,
@@ -79,8 +94,10 @@ impl Buffer {
 	}
 
 	/// Return the length of a suffix of `s` that could be the start of a known tag.
+	/// e.g. `"hello<no"` -> 3, because `"<no"` is a prefix of `"<note>"`.
+	/// e.g. `"hello"` -> 0, because no suffix starts with `'<'`.
 	fn partial_tag_len(s: &str) -> usize {
-		let max_check = s.len().min(15);
+		let max_check = s.len().min(MAX_TAG_LEN);
 		for len in (1..=max_check).rev() {
 			let suffix = &s[s.len() - len..];
 			if !suffix.starts_with('<') {
@@ -100,6 +117,33 @@ impl Buffer {
 		self.drain();
 	}
 
+	/// Drain all pending data, processing any tags found.
+	/// Used on the last call when we know no more data will arrive
+	/// Unlike `drain`, this does not hold back partial tag suffixes.
+	fn drain_remaining(&mut self) {
+		loop {
+			if self.pending.is_empty() {
+				break;
+			}
+			match Self::find_first_tag(&self.pending) {
+				Some((pos, tag)) => {
+					if pos > 0 {
+						let before = self.pending[..pos].to_string();
+						self.emit_text(&before);
+					}
+					let after_pos = pos + tag.len();
+					self.pending = self.pending[after_pos..].to_string();
+					self.handle_tag(tag);
+				}
+				None => {
+					let remaining = std::mem::take(&mut self.pending);
+					self.emit_text(&remaining);
+					break;
+				}
+			}
+		}
+	}
+
 	fn drain(&mut self) {
 		loop {
 			let partial = Self::partial_tag_len(&self.pending);
@@ -108,9 +152,9 @@ impl Buffer {
 				break;
 			}
 
-			let safe = self.pending[..safe_len].to_string();
+			let result = Self::find_first_tag(&self.pending[..safe_len]);
 
-			match Self::find_first_tag(&safe) {
+			match result {
 				Some((pos, tag)) => {
 					if pos > 0 {
 						let before = self.pending[..pos].to_string();
@@ -194,7 +238,7 @@ impl Buffer {
 					if self.state == State::Write && buffered.ends_with("```") {
 						let whitespace = " ".repeat(3);
 						let formatted = format!("\r{}", whitespace);
-						let line = buffered.replace("```", &formatted);
+						let line = format!("{}{}", &buffered[..buffered.len() - 3], formatted);
 						eprintln!("{}", line);
 					} else {
 						let formatted = clear_format(&buffered);
@@ -222,10 +266,10 @@ impl Buffer {
 	}
 
 	pub fn print_return_remain(&mut self) -> String {
-		// Flush any remaining pending data
+		// Force-drain any remaining pending data, treating it all as safe
+		// (no more data will arrive, so partial tag matching is no longer needed).
 		if !self.pending.is_empty() {
-			let remaining = std::mem::take(&mut self.pending);
-			self.emit_text(&remaining);
+			self.drain_remaining();
 		}
 		self.flush_line();
 
@@ -445,6 +489,28 @@ mod tests {
 	fn angle_bracket_not_a_tag() {
 		let mut buf = Buffer::new();
 		buf.proc("x < y and y > x\n</note>captured");
+		let result = buf.print_return_remain();
+		assert_eq!(result, "captured");
+	}
+
+	#[test]
+	fn stuck_tag_not_emitted_as_raw_text_into_buf() {
+		// When state is Buf and a complete tag is stuck in pending at end-of-stream,
+		// print_return_remain calls emit_text which appends the raw tag into buf.
+		// The tag should be processed, not emitted as literal text.
+		let mut buf = Buffer::new();
+		buf.proc("text<note>detail\n</note>captured<suggest>");
+		// "<suggest>" is stuck in pending. State is Buf (from </note>).
+		// "captured" is in buf.
+		let result = buf.print_return_remain();
+		assert_eq!(result, "captured");
+	}
+
+	#[test]
+	fn stuck_closing_tag_not_emitted_as_raw_text_into_buf() {
+		// Same issue with </suggestions> stuck at end of stream
+		let mut buf = Buffer::new();
+		buf.proc("text<note>detail\n</note>captured</suggestions>");
 		let result = buf.print_return_remain();
 		assert_eq!(result, "captured");
 	}

--- a/module-request-ai/src/buffer.rs
+++ b/module-request-ai/src/buffer.rs
@@ -37,8 +37,21 @@ enum State {
 	Buf,
 }
 
+const TAGS: &[&str] = &[
+	"<suggestions>",
+	"</suggestions>",
+	"<suggest>",
+	"</suggest>",
+	"<note>",
+	"</note>",
+	"<think>",
+	"</think>",
+];
+
 pub struct Buffer {
 	pub buf: String,
+	pending: String,
+	line_buf: String,
 	state: State,
 }
 
@@ -46,18 +59,176 @@ impl Buffer {
 	pub fn new() -> Self {
 		Buffer {
 			buf: String::new(),
+			pending: String::new(),
+			line_buf: String::new(),
 			state: State::Write,
 		}
 	}
+
+	/// Find the first occurrence of any known tag in `s`.
+	fn find_first_tag(s: &str) -> Option<(usize, &'static str)> {
+		let mut best: Option<(usize, &'static str)> = None;
+		for &tag in TAGS {
+			if let Some(pos) = s.find(tag) {
+				if best.is_none() || pos < best.unwrap().0 {
+					best = Some((pos, tag));
+				}
+			}
+		}
+		best
+	}
+
+	/// Return the length of a suffix of `s` that could be the start of a known tag.
+	fn partial_tag_len(s: &str) -> usize {
+		let max_check = s.len().min(15);
+		for len in (1..=max_check).rev() {
+			let suffix = &s[s.len() - len..];
+			if !suffix.starts_with('<') {
+				continue;
+			}
+			for &tag in TAGS {
+				if tag.starts_with(suffix) {
+					return len;
+				}
+			}
+		}
+		0
+	}
+
 	pub fn proc(&mut self, data: &str) {
+		self.pending.push_str(data);
+		self.drain();
+	}
+
+	fn drain(&mut self) {
+		loop {
+			let partial = Self::partial_tag_len(&self.pending);
+			let safe_len = self.pending.len() - partial;
+			if safe_len == 0 {
+				break;
+			}
+
+			let safe = self.pending[..safe_len].to_string();
+
+			match Self::find_first_tag(&safe) {
+				Some((pos, tag)) => {
+					if pos > 0 {
+						let before = self.pending[..pos].to_string();
+						self.emit_text(&before);
+					}
+					let after_pos = pos + tag.len();
+					self.pending = self.pending[after_pos..].to_string();
+					self.handle_tag(tag);
+				}
+				None => {
+					let to_emit = self.pending[..safe_len].to_string();
+					self.pending = self.pending[safe_len..].to_string();
+					self.emit_text(&to_emit);
+					break;
+				}
+			}
+		}
+	}
+
+	fn handle_tag(&mut self, tag: &str) {
+		match tag {
+			"<note>" => {
+				self.flush_line();
+				let warn = format!("{}:", t!("ai-suggestion"))
+					.bold()
+					.blue()
+					.to_string();
+				eprintln!("{}", warn);
+				std::io::stderr().flush().unwrap();
+			}
+			"</note>" => {
+				self.flush_line();
+				self.state = State::Buf;
+			}
+			"<think>" => {
+				self.flush_line();
+				let warn = format!("{}:", t!("ai-thinking")).bold().blue().to_string();
+				eprintln!("{}", warn);
+				std::io::stderr().flush().unwrap();
+				self.state = State::Think;
+			}
+			"</think>" => {
+				self.flush_line();
+				if self.state == State::Think {
+					self.state = State::Write;
+				}
+			}
+			"<suggestions>" | "<suggest>" => {
+				self.flush_line();
+				self.state = State::Buf;
+			}
+			"</suggestions>" | "</suggest>" => {}
+			_ => {}
+		}
+	}
+
+	fn flush_line(&mut self) {
+		if !self.line_buf.is_empty() {
+			eprintln!();
+			std::io::stderr().flush().unwrap();
+			self.line_buf.clear();
+		}
+	}
+
+	fn emit_text(&mut self, text: &str) {
+		if text.is_empty() {
+			return;
+		}
 		match self.state {
-			State::Write => self.proc_write(data),
-			State::Think => self.proc_think(data),
-			State::Buf => self.buf.push_str(data),
+			State::Buf => {
+				self.buf.push_str(text);
+			}
+			State::Write | State::Think => {
+				let mut remaining = text;
+				while let Some(nl_pos) = remaining.find('\n') {
+					let segment = &remaining[..nl_pos];
+					self.line_buf.push_str(segment);
+					let buffered = self.line_buf.trim().to_string();
+					self.line_buf.clear();
+
+					if self.state == State::Write && buffered.ends_with("```") {
+						let whitespace = " ".repeat(3);
+						let formatted = format!("\r{}", whitespace);
+						let line = buffered.replace("```", &formatted);
+						eprintln!("{}", line);
+					} else {
+						let formatted = clear_format(&buffered);
+						eprintln!("{}", formatted);
+					}
+					std::io::stderr().flush().unwrap();
+					remaining = &remaining[nl_pos + 1..];
+				}
+				if !remaining.is_empty() {
+					self.line_buf.push_str(remaining);
+					let buffered = self.line_buf.trim().to_string();
+					if let Some(filled) = fill(&buffered) {
+						self.line_buf.clear();
+						let formatted = clear_format(&filled);
+						eprint!("{}", formatted);
+						self.line_buf
+							.push_str(formatted.split_once("\n").unwrap().1);
+					} else {
+						eprint!("{}", remaining);
+					}
+					std::io::stderr().flush().unwrap();
+				}
+			}
 		}
 	}
 
 	pub fn print_return_remain(&mut self) -> String {
+		// Flush any remaining pending data
+		if !self.pending.is_empty() {
+			let remaining = std::mem::take(&mut self.pending);
+			self.emit_text(&remaining);
+		}
+		self.flush_line();
+
 		let buffered = self.buf.trim().to_string();
 		self.buf.clear();
 		if self.state == State::Buf {
@@ -72,119 +243,209 @@ impl Buffer {
 		}
 		"".to_string()
 	}
+}
 
-	fn proc_write(&mut self, data: &str) {
-		if !data.contains("\n") {
-			self.buf.push_str(data);
-			let buffered = self.buf.trim().to_string();
-			let filled = fill(&buffered);
-			if let Some(filled) = filled {
-				self.buf.clear();
-				let formatted = clear_format(&filled);
-				eprint!("{}", formatted);
-				self.buf.push_str(formatted.split_once("\n").unwrap().1);
-				std::io::stdout().flush().unwrap();
-				return;
-			}
-			eprint!("{}", data);
-			std::io::stdout().flush().unwrap();
-			return;
-		}
+#[cfg(test)]
+mod tests {
+	use super::*;
 
-		let mut data = data.to_string();
-		while data.contains("\n") {
-			let lines = data.split_once("\n").unwrap();
-			let first = lines.0;
-			let last = lines.1;
-			self.buf.push_str(first);
-			let buffered = self.buf.trim().to_string();
-			self.buf.clear();
-			if buffered.ends_with("<note>") {
-				let warn = format!("{}:", t!("ai-suggestion"))
-					.bold()
-					.blue()
-					.to_string();
-				let first = buffered.replace("<note>", &warn);
-				eprintln!("\r{}", first);
-				std::io::stdout().flush().unwrap();
-			} else if buffered.ends_with("</note>") {
-				let tag = "</note>";
-				let whitespace = " ".repeat(tag.len());
-				let clear = whitespace.to_string();
-				let first = buffered.replace("</note>", &clear);
-				eprintln!("\r{}", first);
-				self.state = State::Buf;
-				std::io::stdout().flush().unwrap();
-			} else if buffered.ends_with("<think>") {
-				let tag = "<think>";
-				let warn = format!("{}:", t!("ai-thinking")).bold().blue().to_string();
-				let first = buffered.replace(tag, &warn);
-				self.state = State::Think;
-				eprintln!("\r{}", first);
-				std::io::stdout().flush().unwrap();
-			} else if buffered.ends_with("</think>") {
-				let tag = "</think>";
-				let whitespace = " ".repeat(tag.len());
-				let clear = whitespace.to_string();
-				let first = buffered.replace(tag, &clear);
-				eprintln!("\r{}", first);
-				std::io::stdout().flush().unwrap();
-			} else if buffered.ends_with("```") {
-				let tag = "```";
-				let whitespace = " ".repeat(tag.len());
-				let formatted = format!("\r{}", whitespace);
-				let first = buffered.replace(tag, &formatted);
-				eprintln!("{}", first);
-				std::io::stdout().flush().unwrap();
-			} else {
-				eprintln!("{}", first);
-				std::io::stdout().flush().unwrap();
-			}
-			data = last.to_string();
-		}
-		eprint!("{}", data);
+	// --- find_first_tag ---
+
+	#[test]
+	fn find_first_tag_at_start() {
+		let result = Buffer::find_first_tag("<note>hello");
+		assert_eq!(result, Some((0, "<note>")));
 	}
 
-	fn proc_think(&mut self, data: &str) {
-		if !data.contains("\n") {
-			self.buf.push_str(data);
-			let buffered = self.buf.trim().to_string();
-			let filled = fill(&buffered);
-			if let Some(filled) = filled {
-				self.buf.clear();
-				let formatted = clear_format(&filled);
-				eprint!("{}", formatted);
-				self.buf.push_str(formatted.split_once("\n").unwrap().1);
-				std::io::stdout().flush().unwrap();
-				return;
-			}
-			eprint!("{}", data);
-			std::io::stdout().flush().unwrap();
-			return;
-		}
+	#[test]
+	fn find_first_tag_mid_string() {
+		let result = Buffer::find_first_tag("some text<note>more");
+		assert_eq!(result, Some((9, "<note>")));
+	}
 
-		let mut data = data.to_string();
-		while data.contains("\n") {
-			let lines = data.split_once("\n").unwrap();
-			let first = lines.0;
-			let last = lines.1;
-			self.buf.push_str(first);
-			let buffered = self.buf.trim().to_string();
-			self.buf.clear();
-			if buffered.ends_with("</think>") {
-				let tag = "</think>";
-				let whitespace = " ".repeat(tag.len());
-				let clear = whitespace.to_string();
-				let first = buffered.replace(tag, &clear);
-				self.state = State::Write;
-				eprintln!("\r{}", first);
-				std::io::stdout().flush().unwrap();
-			} else {
-				eprintln!("{}", first);
-				std::io::stdout().flush().unwrap();
-			}
-			data = last.to_string();
-		}
-		eprint!("{}", data);
+	#[test]
+	fn find_first_tag_none() {
+		let result = Buffer::find_first_tag("no tags here");
+		assert_eq!(result, None);
+	}
+
+	#[test]
+	fn find_first_tag_picks_earliest() {
+		let result = Buffer::find_first_tag("a<think>b<note>c");
+		assert_eq!(result, Some((1, "<think>")));
+	}
+
+	#[test]
+	fn find_first_tag_closing() {
+		let result = Buffer::find_first_tag("text</note>rest");
+		assert_eq!(result, Some((4, "</note>")));
+	}
+
+	#[test]
+	fn find_first_tag_suggestions() {
+		let result = Buffer::find_first_tag("x<suggestions>y");
+		assert_eq!(result, Some((1, "<suggestions>")));
+	}
+
+	#[test]
+	fn find_first_tag_suggest() {
+		let result = Buffer::find_first_tag("x<suggest>y");
+		assert_eq!(result, Some((1, "<suggest>")));
+	}
+
+	// --- partial_tag_len ---
+
+	#[test]
+	fn partial_tag_none() {
+		assert_eq!(Buffer::partial_tag_len("hello"), 0);
+	}
+
+	#[test]
+	fn partial_tag_open_angle() {
+		// "<" could be the start of any tag
+		assert_eq!(Buffer::partial_tag_len("hello<"), 1);
+	}
+
+	#[test]
+	fn partial_tag_note_prefix() {
+		assert_eq!(Buffer::partial_tag_len("hello<no"), 3);
+	}
+
+	#[test]
+	fn partial_tag_think_prefix() {
+		assert_eq!(Buffer::partial_tag_len("data<thi"), 4);
+	}
+
+	#[test]
+	fn partial_tag_closing_prefix() {
+		assert_eq!(Buffer::partial_tag_len("data</no"), 4);
+	}
+
+	#[test]
+	fn partial_tag_full_tag_is_not_partial() {
+		// A complete tag should be found by find_first_tag, not partial_tag_len.
+		// partial_tag_len only looks for prefixes that don't form a complete tag.
+		// "<note>" is 6 chars; if it ends the string, partial_tag_len checks
+		// suffixes of length 1..=6. "<note>" starts_with "<note>" → matches.
+		// But that's fine because drain() calls find_first_tag on safe portion first.
+		let len = Buffer::partial_tag_len("text<note>");
+		assert!(len > 0); // it does match as a prefix of "<note>"
+	}
+
+	#[test]
+	fn partial_tag_suggestions_prefix() {
+		assert_eq!(Buffer::partial_tag_len("x<sug"), 4);
+	}
+
+	// --- Integration: proc + print_return_remain ---
+
+	#[test]
+	fn basic_note_then_suggestion() {
+		let mut buf = Buffer::new();
+		buf.proc("explanation\n<note>\ndetail\n</note>\nsuggestion content");
+		let result = buf.print_return_remain();
+		assert_eq!(result, "suggestion content");
+	}
+
+	#[test]
+	fn note_tag_inline_with_text() {
+		let mut buf = Buffer::new();
+		buf.proc("hello<note>world\n</note>the suggestion");
+		let result = buf.print_return_remain();
+		assert_eq!(result, "the suggestion");
+	}
+
+	#[test]
+	fn tag_split_across_chunks() {
+		let mut buf = Buffer::new();
+		buf.proc("text<no");
+		buf.proc("te>inside note\n</no");
+		buf.proc("te>captured");
+		let result = buf.print_return_remain();
+		assert_eq!(result, "captured");
+	}
+
+	#[test]
+	fn think_then_write_then_buf() {
+		let mut buf = Buffer::new();
+		buf.proc("<think>thinking...\n</think>explanation\n<note>note\n</note>suggestion");
+		let result = buf.print_return_remain();
+		assert_eq!(result, "suggestion");
+	}
+
+	#[test]
+	fn suggestions_tag_transitions_to_buf() {
+		let mut buf = Buffer::new();
+		buf.proc("text<suggestions>cmd1\ncmd2");
+		let result = buf.print_return_remain();
+		assert_eq!(result, "cmd1\ncmd2");
+	}
+
+	#[test]
+	fn suggest_tag_transitions_to_buf() {
+		let mut buf = Buffer::new();
+		buf.proc("text<suggest>the command");
+		let result = buf.print_return_remain();
+		assert_eq!(result, "the command");
+	}
+
+	#[test]
+	fn suggestions_fallback_in_print_return_remain() {
+		// If we never hit </note> or <suggest> during streaming,
+		// print_return_remain falls back to splitting on <suggestions>
+		let mut buf = Buffer::new();
+		// Manually put data in buf without state transition
+		buf.buf = "preamble<suggestions>the commands".to_string();
+		let result = buf.print_return_remain();
+		assert_eq!(result, "the commands");
+	}
+
+	#[test]
+	fn no_tags_returns_empty() {
+		let mut buf = Buffer::new();
+		buf.proc("just some text\n");
+		let result = buf.print_return_remain();
+		assert_eq!(result, "");
+	}
+
+	#[test]
+	fn multiple_chunks_no_newlines() {
+		let mut buf = Buffer::new();
+		buf.proc("a");
+		buf.proc("b");
+		buf.proc("c");
+		buf.proc("<note>");
+		buf.proc("d</note>result");
+		let result = buf.print_return_remain();
+		assert_eq!(result, "result");
+	}
+
+	#[test]
+	fn think_block_split_across_many_chunks() {
+		let mut buf = Buffer::new();
+		buf.proc("<th");
+		buf.proc("ink>");
+		buf.proc("deep thought\n");
+		buf.proc("</th");
+		buf.proc("ink>");
+		buf.proc("after think</note>captured");
+		let result = buf.print_return_remain();
+		assert_eq!(result, "captured");
+	}
+
+	#[test]
+	fn empty_input() {
+		let mut buf = Buffer::new();
+		buf.proc("");
+		let result = buf.print_return_remain();
+		assert_eq!(result, "");
+	}
+
+	#[test]
+	fn angle_bracket_not_a_tag() {
+		let mut buf = Buffer::new();
+		buf.proc("x < y and y > x\n</note>captured");
+		let result = buf.print_return_remain();
+		assert_eq!(result, "captured");
 	}
 }


### PR DESCRIPTION
The buffer previously only detected tags like <note>, </note>, <think>, and </think> when they fell exactly at the end of a newline-delimited line via ends_with checks. This broke when models placed tags inline or when streaming chunks split a tag across boundaries.

Replaces with a scan-based approach that finds tags anywhere in the accumulated buffer, handles partial tags split across streaming chunks, and adds 26 unit tests covering tag detection, partial matching, state transitions, and chunk-splitting edge cases.

---

Some background:

Here's what I'm trying to fix:

```
~/code/sandbox/pay-respects git:(main) ✗
 > madeupcommand this is a test
zsh: Command not found: madeupcommand

~/code/sandbox/pay-respects git:(main) ✗
 > f
Suggestion from AI:
command `madeupcommand` was not found. It appears to be a placeholder or typo.  o.
Without more context, it is unclear what the intended command is. However, if
the argument `this is a test` is a hint, the user may be trying to echo or print
text, run a test, or execute a simple shell command.
</note>
<suggest>
echo "this is a test"
<br>
printf "%s\n" "this is a test"
<br>
echo "this is a test" | bash
</suggest>No suggestion found for command: madeupcommand this is a test

If you think there should be a suggestion, please open an issue or send a pull request!
https://github.com/iffse/pay-respects
```

