### PR TITLE
fix: pass full command line to CNF handler in templates

### DIFF
--- a/core/templates/init.bash
+++ b/core/templates/init.bash
@@ -26,6 +26,6 @@ bind -x '"\C-x\C-x":__pr_inline'
 
 {%- if cnf %}
 command_not_found_handle() {
-	eval $(__pr_base "cnf" "$@")
+	eval $(__pr_base "cnf" "$*")
 }
 {% endif %}

--- a/core/templates/init.zsh
+++ b/core/templates/init.zsh
@@ -26,6 +26,6 @@ bindkey '^X^X' __pr_inline
 
 {%- if cnf %}
 command_not_found_handler() {
-	eval $(__pr_base "cnf" "$@")
+	eval $(__pr_base "cnf" "$*")
 }
 {% endif %}


### PR DESCRIPTION
## Pull Request Description

Currently, pay-respects omits all command arguments when handling a CNF. For example, on Bash, even though the misspelled command `jjj status` can be autocorrected to use `jj`, the argument is left out:

<img width="952" height="214" alt="bash bad 1" src="https://github.com/user-attachments/assets/bc811d56-569e-4def-b995-0a1c5b9bb596" />

<img width="1173" height="393" alt="bash bad 2" src="https://github.com/user-attachments/assets/9fea7d9a-2966-4d93-8375-dc4165aadaef" />

This PR fixes the above problem by using `"$*"`, which quotes all members into a single string argument.

**Verification on bash:**

<img width="951" height="244" alt="bash good 1" src="https://github.com/user-attachments/assets/fd0babc2-c5f2-4e65-b517-cc3191e36133" />

<img width="1612" height="232" alt="bash good 2" src="https://github.com/user-attachments/assets/348fe445-f629-44ad-a3e4-55b8033ddf84" />

## Checklists

Please check the boxes that apply to this pull request:

- [x] I have tested and validated my changes
- [ ] I have used generative AI tools in the development of this pull request

Please select the type of change that best describes your pull request:

- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] refactor
- [ ] tests
- [ ] performance
- [ ] security
- [ ] other
