### PR TITLE
feat: Add git-switch -c missing

### DIFF
--- a/rules/git.toml
+++ b/rules/git.toml
@@ -211,3 +211,14 @@ suggest = [
 #[cmd_contains(tag)]
 {{command}} --force''',
 ]
+
+[[match_err]]
+pattern = [
+  "fatal: invalid reference:"
+]
+suggest = [
+'''
+#[cmd_contains(switch)]
+{{command[0]}} switch -c {{command[2:]}}'''
+]
+


### PR DESCRIPTION
## Pull Request Description

I commonly type `git switch rawr` when i meant `git switch -c rawr`, that is - creating a branch and switching to it.
It could possibly be a typo of a branch name, but rarely for me, due to tab completion.

I've tested this as a runtime rule

## Checklists

Please check the boxes that apply to this pull request:

- [ ] I have tested and validated my changes
- [ ] I have used generative AI tools in the development of this pull request

Please select the type of change that best describes your pull request:

- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] refactor
- [ ] tests
- [ ] performance
- [ ] security
- [ ] other
