### PR TITLE
fix: pass path to zellij dump-screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Zellij: `dump-screen` requires a path argument, so terminal capture failed
+and leaked a usage error to the terminal.
+
 ## [0.8.8]
 
 ### Fixed

--- a/core/src/integrations.rs
+++ b/core/src/integrations.rs
@@ -111,8 +111,11 @@ fn get_error_from_zellij(shell: &str, prefix: &str, command: &str) -> Option<Str
 		return None;
 	}
 
-	let capture_command = "zellij action dump-screen --full";
-	let output = command_output(shell, capture_command);
+	let file = NamedTempFile::new().ok()?;
+	let path = file.path().to_str()?;
+	let capture_command = format!("zellij action dump-screen --full {}", path);
+	let _ = command_output(shell, &capture_command);
+	let output = std::fs::read_to_string(path).ok()?;
 
 	parse_output(prefix, command, &output)
 }


### PR DESCRIPTION
## Pull Request Description

Zellij dumps server-side, so `dump-screen` takes a mandatory <PATH> instead of writing to stdout. Capture returned zellij's usage error, which leaked to the terminal, and fell back to re-running the command.

Dump to a temp file and read it back, same as the screen branch.


<!--
Please provide a detailed description of the changes made in this pull request, including any relevant context or background information that may be helpful for reviewers to understand the purpose and impact of the changes.
-->

## Checklists

<!--
Check with an "x" on the boxes, e.g. [x]
-->

Please check the boxes that apply to this pull request:

- [x] I have tested and validated my changes
- [x] I have used generative AI tools in the development of this pull request

Please select the type of change that best describes your pull request:

- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] refactor
- [ ] tests
- [ ] performance
- [ ] security
- [ ] other
